### PR TITLE
missing import statements added

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -12,7 +12,7 @@ Connect
   Connect to a COMPASS GraphQL endpoint and retrieve
   all available compendium as a list of Compendium objects
   '''
-  from pycompass import Connect, Compendium, Module
+  from pycompass import Connect, Compendium, Module, Sample, Platform, Experiment, Ontology, SampleSet, Plot
 
   url = 'http://compass.fmach.it/graphql'
   conn = Connect(url)


### PR DESCRIPTION
Update examples.rst  with missing import statements: now all the examples work out of the box.